### PR TITLE
Update supported Rails version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the application template that I use for my Rails 5.0 projects. As a  Rai
 
 This template currently works with:
 
-* Rails 4.0.x
+* Rails 5.0.x
 * PostgreSQL
 
 ## Installation


### PR DESCRIPTION
The documentation mistakenly says that Rails 4 is required, when in fact Rails 5.0.x is supported.